### PR TITLE
Dynamic Linking Constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,8 @@ use_rust_alloc = []
 # Builds libdeflate in a freestanding mode (no reliance on libc).
 # This is useful for targets that don't have a C stdlib (e.g. wasm32-unknown-unknown).
 freestanding = ["libdeflate-sys/freestanding", "use_rust_alloc"]
+# Link to system/external libdeflate library when available, instead of
+# building it from source.
+dynamic = ["libdeflate-sys/dynamic"]
 
 [workspace]

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -18,7 +18,8 @@ build = "build.rs"
 
 [build-dependencies]
 cc = "1.0"
-pkg-config = "0.3.9"
+pkg-config = { version = "0.3.9", optional = true }
 
 [features]
 freestanding = []
+dynamic = ["pkg-config"]

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 fn main() {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
+    #[cfg(feature = "dynamic")]
     if pkg_config::Config::new()
         .print_system_libs(false)
         .cargo_metadata(true)

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -8,6 +8,7 @@ fn main() {
     if pkg_config::Config::new()
         .print_system_libs(false)
         .cargo_metadata(true)
+        .exactly_version("1.19")
         .probe("libdeflate")
         .is_ok()
     {

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -46,7 +46,7 @@ fn main() {
     let src = Path::new("libdeflate");
     let include = dst.join("include");
     fs::create_dir_all(&include).unwrap();
-    fs::copy(src.join("libdeflate.h"), &include.join("libdeflate.h")).unwrap();
+    fs::copy(src.join("libdeflate.h"), include.join("libdeflate.h")).unwrap();
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}", include.display());
 }


### PR DESCRIPTION
This PR does two things:
* It constrains the `pkg-config` lookup to the same library version the crate would otherwise build
* It moves the `pkg-config` functionality behind a `dynamic` feature flag, giving downstream users the option to use it or not

I didn't make the dynamic feature a default, but would be happy to refactor the PR if you think it should be. :wink: 

For context, this feature gate could be useful when building software for general distribution (rather than personal use). I try to limit the number of package dependencies in my own `.deb` builds for example since Debian, Ubuntu, Mint, et al, almost never carry the same versions of anything. Haha.

Thanks!