### PR TITLE
fix(test): call `libdeflate_free_compressor` to free the compressor

### DIFF
--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -188,6 +188,7 @@ mod tests {
                                                  out_data.len());
             assert_ne!(sz, 0);
             assert!(sz < 100);
+            libdeflate_free_compressor(compressor);
         }
     }
 


### PR DESCRIPTION
as title above. previous test case implementation indicated a wong style to call `libdeflate_alloc_compressor`
