### PR TITLE
Update libdeflate to v1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming Release]
 
+## [1.26.0]
+
+- Updated libdeflate to v1.26
+
 ## [1.25.2] - 2026/02/08
 
 - Added `Crc::with_initial` and `Adler32::with_initial` constructors (#52, thanks @vbe0201).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.26.0]
 
-- Updated libdeflate to v1.26
+- Updated libdeflate to v1.26 (#55, thanks @musicinmybrain).
 
 ## [1.25.2] - 2026/02/08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflater"
-version = "1.25.2"
+version = "1.26.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [dependencies]
-libdeflate-sys = { version = "1.25.2", path = "libdeflate-sys" }
+libdeflate-sys = { version = "1.26.0", path = "libdeflate-sys" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation](https://docs.rs/libdeflater/badge.svg)](https://docs.rs/libdeflater)
 
 ```
-libdeflater = "1.25.2"
+libdeflater = "1.26.0"
 ```
 
 `libdeflater` is a thin wrapper library around [libdeflate](https://github.com/ebiggers/libdeflate). Libdeflate 

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflate-sys"
-version = "1.25.2"
+version = "1.26.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 links = "libdeflate"
 edition = "2018"

--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -161,7 +161,9 @@ mod tests {
     #[test]
     fn making_compressor_with_negative_compression_lvl_fails() {
         unsafe {
-            let ptr = libdeflate_alloc_compressor(-1);
+            // Since 1.26, compression level -1 is a valid alias for the default compression level.
+            // Other negative compression levels should still fail.
+            let ptr = libdeflate_alloc_compressor(-2);
             assert!(ptr.is_null());
         }
     }


### PR DESCRIPTION
The last time we did this was https://github.com/libdeflater/libdeflater/pull/50. Tested with `cargo test --workspace`.

https://github.com/ebiggers/libdeflate/compare/v1.25...v1.26

```
# libdeflate release notes

## Version 1.26

* Added support for compression level -1 as an alias for the default compression
  level (6).
* libdeflate now requires a C11 compiler.  For Visual Studio builds, this bumps
  the minimum version up to Visual Studio 2019 v16.8.
* Fixed build failures with clang 18 specifically (clang 19+ unaffected).
* Fixed build failure with glibc 2.43 and later.
* Enabled unaligned access optimizations on all PowerPC variants.
* Improved CRC-32 performance on Arm Neoverse V-Series processors by selecting a
  faster CRC-32 implementation for these processors.
* The CMakeLists.txt now supports the user overriding `CMAKE_C_FLAGS_RELEASE`.
* The CMakeLists.txt no longer runs installation commands when it is built as a
  subproject.
* The prebuilt Windows binaries are now 64-bit only.  Prebuilt 32-bit binaries
  are no longer provided, though they can still be built by users.
```

The `libdeflate` change that needed handling was the first one in the release notes: in `making_compressor_with_negative_compression_lvl_fails`, we were checking that asking compression level `-1` fails, but it’s now valid. I added a comment about this, and tried to preserve the original intent by testing `-2` instead.